### PR TITLE
Update Nations.json

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -3860,8 +3860,7 @@
 
 	"uniqueName": "Magyar Majesty",
 	"uniques": [
-	"[-25]% construction time for [All] improvements <in [River] tiles> <within [1] tiles of a [City center]>",
-	"[+1 Production] from [{improved} {River}] tiles [in all cities]",
+	"[-25]% construction time for [All] improvements <in [River] tiles>",
 	"[Gold] cost of purchasing [Mounted] units [-20]%"],
 
 	"spyNames": ["Árpád", "Attila", "Bence", "Ferenc", "Gábor", "István", "László", "Máté", "Tamás", "Zoltán"],


### PR DESCRIPTION
+1 Production per tile can easily mean +4 production in capital in the very early game when you're construction settlers. I propose removing it, and instead make the other part of the UA less situational.