### PR TITLE
Update TileImprovements.json

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -167,12 +167,10 @@
 	{
 		"name": "Industrial Greenhouse",
 		"uniqueTo": "Arizona",
-		"terrainsCanBeBuiltOn": ["Desert", "Plains", "Grassland"],
+		"food": 2,
+		"terrainsCanBeBuiltOn": ["Desert"],
 		"turnsToBuild": 12,
-		"uniques": ["[+1 Food] for each adjacent [Farm]", "[+1 Gold, +1 Food] for each adjacent [Plantation]",
-		"Cannot be built on [Desert] tiles <with [1] to [6] neighboring [Industrial Greenhouse] tiles>",
-		"Cannot be built on [Plains] tiles <with [1] to [6] neighboring [Industrial Greenhouse] tiles>",
-		"Cannot be built on [Grassland] tiles <with [1] to [6] neighboring [Industrial Greenhouse] tiles>"],
+		"uniques": ["[+1 Food] for each adjacent [Industrial Greenhouse]"],
 		"techRequired": "Fertilizer",
 	},
 		//The Cree


### PR DESCRIPTION
Having 8-food tiles spread over your empire is way too OP. Maybe limit the 8-yield tiles to just desert, which is a fairly small area.