### PR TITLE
Update Nations.json

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -5732,20 +5732,15 @@
 	"innerColor": [252, 254, 252],
 
 	"uniqueName": "Dolphin Island",
-	"uniques": ["Comment [non-[Lakes] Water tiles will have their [Food] and [Production] yields replaced and gain [Culture], [Science], or [Happiness] instead]",
+	"uniques": ["Comment [non-[Lakes] Water tiles will have their base [Food] and [Production] yields replaced and gain [Culture], [Science], and [Happiness] instead]",
 	"Comment [Additional [Culture] and [Science] yield from non-[Lakes] Water tiles after discovering [Ecology]]",
 
 	"[-1 Food, +1 Culture, +1 Science] from every [Coast] <hidden from users>",
 	"[-1 Food, +1 Culture, +1 Science] from every [Ocean] <hidden from users>",
 	"[-1 Production, -1 Food, +1 Culture, +1 Science, +1 Happiness] from every [Atoll] <hidden from users>",
 
-	"[-1 Food, +1 Culture, +1 Science] from every [Fish] <in cities with a [Lighthouse]> <hidden from users>",
 	"[-1 Food, +1 Culture, +1 Science] from every [Coast] <in cities with a [Lighthouse]> <hidden from users>",
 	"[-1 Food, +1 Culture, +1 Science] from every [Ocean] <in cities with a [Lighthouse]> <hidden from users>",
-
-	"[-1 Production, +1 Happiness] from every [Water resource] <in cities with a [Harbor]> <hidden from users>",
-	"[-1 Production, +1 Happiness] from every [Water resource] <in cities with a [Seaport]> <hidden from users>",
-	"[-1 Production, +1 Happiness] from every [Fishing Boats] <in cities following our religion> <after adopting [God of the Sea]> <hidden from users>",
 
 	"[+1 Culture, +1 Science] from every [Coast] <hidden from users> <after discovering [Ecology]>",
 	"[+1 Culture, +1 Science] from every [Ocean] <hidden from users> <after discovering [Ecology]>"],

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -5732,25 +5732,23 @@
 	"innerColor": [252, 254, 252],
 
 	"uniqueName": "Dolphin Island",
-	"uniques": ["Comment [non-[Lakes] Water tiles will have their stats and subsequent stat additions replaced with [Culture], [Science], or [Happiness] instead]",
-	"Comment [Double [Culture] and [Science] yield from non-[Lakes] Water tiles after discovering [Ecology]]",
+	"uniques": ["Comment [non-[Lakes] Water tiles will have their [Food] and [Production] yields replaced and gain [Culture], [Science], or [Happiness] instead]",
+	"Comment [Additional [Culture] and [Science] yield from non-[Lakes] Water tiles after discovering [Ecology]]",
 
-	"[-2 Food, -2 Gold, +1 Culture, +1 Science] from every [Coast] <hidden from users>",
-	"[-2 Food, -2 Gold, +2 Culture, +1 Science] from every [Ocean] <hidden from users>",
-	"[-2 Production, +2 Happiness] from every [Atoll] <hidden from users>",
+	"[-1 Food, +1 Culture, +1 Science] from every [Coast] <hidden from users>",
+	"[-1 Food, +1 Culture, +1 Science] from every [Ocean] <hidden from users>",
+	"[-1 Production, -1 Food, +1 Culture, +1 Science, +1 Happiness] from every [Atoll] <hidden from users>",
 
-	"[-1 Food, +1 Science] from every [Fish] <in cities with a [Lighthouse]> <hidden from users>",
-	"[-1 Food, +1 Science] from every [Coast] <in cities with a [Lighthouse]> <hidden from users>",
-	"[-1 Food, +1 Science] from every [Ocean] <in cities with a [Lighthouse]> <hidden from users>",
+	"[-1 Food, +1 Culture, +1 Science] from every [Fish] <in cities with a [Lighthouse]> <hidden from users>",
+	"[-1 Food, +1 Culture, +1 Science] from every [Coast] <in cities with a [Lighthouse]> <hidden from users>",
+	"[-1 Food, +1 Culture, +1 Science] from every [Ocean] <in cities with a [Lighthouse]> <hidden from users>",
 
 	"[-1 Production, +1 Happiness] from every [Water resource] <in cities with a [Harbor]> <hidden from users>",
+	"[-1 Production, +1 Happiness] from every [Water resource] <in cities with a [Seaport]> <hidden from users>",
+	"[-1 Production, +1 Happiness] from every [Fishing Boats] <in cities following our religion> <after adopting [God of the Sea]> <hidden from users>",
 
-	"[+100]% Yield from every [Coast] <hidden from users> <after discovering [Ecology]>",
-	"[+100]% Yield from every [Ocean] <hidden from users> <after discovering [Ecology]>",
-
-	"[-1 Production, -1 Food, +1 Happiness, +1 Culture] from every [Water resource] <in cities with a [Seaport]> <hidden from users>",
-
-	"Cannot build [Settler] units"],
+	"[+1 Culture, +1 Science] from every [Coast] <hidden from users> <after discovering [Ecology]>",
+	"[+1 Culture, +1 Science] from every [Ocean] <hidden from users> <after discovering [Ecology]>"],
 
 	"spyNames": ["Fernão", "Gonçalo", "Amerigo", "Claude", "João", "Pedro", "Maria", "Carlos", "Ana", "Miguel"],
 	"cities": ["Vila dos Remédios"],


### PR DESCRIPTION
The current unique is pretty inconsistent in replacing yields. Maybe go for consistent 1 food -> 1 culture + 1 science, 1 production -> 1 happiness? Maybe this is too distortive to gameplay and we should keep fish bonus yields. 

Removing the ability to build settlers is very very influential on game balance. If you want to limit them to 1 city, it's probably best to turn it into a city state, or they must receive very powerful buffs to make 1-city play viable.

Edit: let's only replace the base yields (without fish food you can't grow and work the special yield water tiles).